### PR TITLE
Enable WebSockets Support for Zephyr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ option(CIVETWEB_ENABLE_IPV6 "Enables the IP version 6 support" OFF)
 message(STATUS "IP Version 6 - ${CIVETWEB_ENABLE_IPV6}")
 
 # Websocket support
-option(CIVETWEB_ENABLE_WEBSOCKETS "Enable websockets connections" OFF)
+option(CIVETWEB_ENABLE_WEBSOCKETS "Enable websockets connections" ON)
 message(STATUS "Websockets support - ${CIVETWEB_ENABLE_WEBSOCKETS}")
 
 # Server statistics support
@@ -627,4 +627,3 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_PACKAGE_DEPENDS}")
 
 # Finalize CPack settings
 include(CPack)
-

--- a/docs/UserManual.md
+++ b/docs/UserManual.md
@@ -470,6 +470,11 @@ if the proper network services are installed (Zeroconf, mDNS, Bonjour,
 Avahi). When using a hostname, you need to test in your particular network
 environment - in some cases, you might need to resort to a fixed IP address.
 
+If you want to use an ephemeral port (i.e. let the operating system choose
+a port number), use `0` for the port number. This will make it necessary to 
+communicate the port number to clients via other means, for example mDNS 
+(or Zeroconf, Bonjour or Avahi).
+
 ### max\_request\_size `16384`
 Size limit for HTTP request headers and header data returned from CGI scripts, in Bytes.
 A buffer of the configured size is pre allocated for every worker thread.

--- a/include/CivetServer.h
+++ b/include/CivetServer.h
@@ -4,8 +4,8 @@
  * License http://opensource.org/licenses/mit-license.php MIT License
  */
 
-#ifndef _CIVETWEB_SERVER_H_
-#define _CIVETWEB_SERVER_H_
+#ifndef CIVETSERVER_HEADER_INCLUDED
+#define CIVETSERVER_HEADER_INCLUDED
 #ifdef __cplusplus
 
 #include "civetweb.h"
@@ -646,4 +646,4 @@ class CIVETWEB_CXX_API CivetServer
 };
 
 #endif /*  __cplusplus */
-#endif /* _CIVETWEB_SERVER_H_ */
+#endif /* CIVETSERVER_HEADER_INCLUDED */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -17314,7 +17314,7 @@ websocket_client_thread(void *data)
 
 	void *user_thread_ptr = NULL;
 
-#if !defined(_WIN32)
+#if !defined(__ZEPHYR__)
 	struct sigaction sa;
 
 	/* Ignore SIGPIPE */

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -14568,6 +14568,9 @@ set_ports_option(struct mg_context *phys_ctx)
 	int portsTotal = 0;
 	int portsOk = 0;
 
+	const char* opt_txt;
+	long opt_max_connections;
+
 	if (!phys_ctx) {
 		return 0;
 	}
@@ -14734,12 +14737,12 @@ set_ports_option(struct mg_context *phys_ctx)
 			continue;
 		}
 
-		const char* p = phys_ctx->dd.config[MAX_CONNECTIONS];
-		const long opt_max_connections = strtol(p, NULL, 10);
-		if(opt_max_connections > INT_MAX || opt_max_connections < 1) {
+		opt_txt = phys_ctx->dd.config[MAX_CONNECTIONS];
+		opt_max_connections = strtol(opt_txt, NULL, 10);
+		if ((opt_max_connections > INT_MAX) || (opt_max_connections < 1)) {
 			mg_cry_ctx_internal(phys_ctx, 
 					    "max_connections value \"%s\" is invalid", 
-					    p);
+				opt_txt);
 			continue;
 		}
 

--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -299,6 +299,7 @@ __cyg_profile_func_exit(void *this_fn, void *call_site)
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #endif /* !_WIN32_WCE */
@@ -11031,14 +11032,14 @@ abort_process(void *data)
 	ret_pid = waitpid(proc->pid, &status, WNOHANG);
 	if ((ret_pid != (pid_t)-1) && (status == 0)) {
 		/* Stop child process */
-		DEBUG_TRACE("CGI timer: Stop child process %p\n", proc->pid);
+		DEBUG_TRACE("CGI timer: Stop child process %d\n", proc->pid);
 		kill(proc->pid, SIGABRT);
 
 		/* Wait until process is terminated (don't leave zombies) */
 		while (waitpid(proc->pid, &status, 0) != (pid_t)-1) /* nop */
 			;
 	} else {
-		DEBUG_TRACE("CGI timer: Child process %p already stopped\n", proc->pid);
+		DEBUG_TRACE("CGI timer: Child process %d already stopped\n", proc->pid);
 	}
 	/* Dec reference counter */
 	refs = mg_atomic_dec(&proc->references);

--- a/src/main.c
+++ b/src/main.c
@@ -2985,15 +2985,13 @@ main(int argc, char *argv[])
 @end
 
 @implementation Civetweb
-- (void)openBrowser
-{
+- (void)openBrowser {
 	[[NSWorkspace sharedWorkspace]
 	    openURL:[NSURL URLWithString:[NSString stringWithUTF8String:
 	                                               get_url_to_first_open_port(
 	                                                   g_ctx)]]];
 }
-- (void)editConfig
-{
+- (void)editConfig {
 	create_config_file(g_ctx, g_config_file_name);
 	NSString *path = [NSString stringWithUTF8String:g_config_file_name];
 	if (![[NSWorkspace sharedWorkspace] openFile:path
@@ -3006,8 +3004,7 @@ main(int argc, char *argv[])
 		(void)[alert runModal];
 	}
 }
-- (void)shutDown
-{
+- (void)shutDown {
 	[NSApp terminate:nil];
 }
 @end

--- a/src/mod_lua.inl
+++ b/src/mod_lua.inl
@@ -2050,6 +2050,7 @@ prepare_lua_request_info(struct mg_connection *conn, lua_State *L)
 		reg_int(L, "status", conn->status_code);
 	}
 
+	/* Table "HTTP headers" */
 	lua_pushstring(L, "http_headers");
 	lua_newtable(L);
 	for (i = 0; i < conn->request_info.num_headers; i++) {
@@ -2059,6 +2060,18 @@ prepare_lua_request_info(struct mg_connection *conn, lua_State *L)
 	}
 	lua_rawset(L, -3);
 
+	/* Table "Client Certificate" */
+	if (conn->request_info.client_cert) {
+		lua_pushstring(L, "client_cert");
+		lua_newtable(L);
+		reg_string(L, "subject", conn->request_info.client_cert->subject);
+		reg_string(L, "issuer", conn->request_info.client_cert->issuer);
+		reg_string(L, "serial", conn->request_info.client_cert->serial);
+		reg_string(L, "finger", conn->request_info.client_cert->finger);
+		lua_rawset(L, -3);
+	}
+
+	/* End of request_info */
 	lua_rawset(L, -3);
 }
 


### PR DESCRIPTION
This PR enables WebSocket support for Zephyr-RTOS. The changes are trivial and consisting of two lines: please see the single one commit.