### PR TITLE
Enable WebSockets Support for Zephyr-RTOS

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -17314,7 +17314,7 @@ websocket_client_thread(void *data)
 
 	void *user_thread_ptr = NULL;
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ZEPHYR__)
 	struct sigaction sa;
 
 	/* Ignore SIGPIPE */


### PR DESCRIPTION
Enables WebSockets support for Zephyr RTOS.

The changes are only two lines  of code similar to those for HTTP server (see commits).

This changes allows me running my currently under development [samples/net/sockets/websocket_server](https://github.com/Nukersson/zephyr/tree/websocket_server_sample) on my `nucleo_h745zi_q` board (please choose M7 core).