### PR TITLE
civetweb: WebSockets support for Zephyr

### DIFF
--- a/src/civetweb.c
+++ b/src/civetweb.c
@@ -17314,7 +17314,7 @@ websocket_client_thread(void *data)
 
 	void *user_thread_ptr = NULL;
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ZEPHYR__)
 	struct sigaction sa;
 
 	/* Ignore SIGPIPE */


### PR DESCRIPTION
Enable websockets support for Zephyr.
To use, pass `-DCIVETWEB_ENABLE_WEBSOCKETS=ON` to west.

Signed-off-by: Alexander Kozhinov <AlexanderKozhinov@yandex.com>
Signed-off-by: Piotr Zierhoffer <pzierhoffer@antmicro.com>