### PR TITLE
cmake: relax minimum version requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Determines what CMake APIs we can rely on
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 2.8.11...3.13.1)
 if (${CMAKE_VERSION} VERSION_GREATER 3.2.2)
   cmake_policy(VERSION 3.2.2)
 endif()


### PR DESCRIPTION
Support for 2.8.12 is being deprecated, so require a range to make the
warnings go away.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>